### PR TITLE
Fix recursive ripple_send_line mapping

### DIFF
--- a/plugin/ripple.vim
+++ b/plugin/ripple.vim
@@ -31,7 +31,7 @@ nnoremap <silent> <Plug>(ripple_open_repl) :call ripple#open_repl()<cr>
 nnoremap <silent> <expr> <Plug>(ripple_send_motion) ripple#send_motion()
 nnoremap <silent> <Plug>(ripple_send_previous) :call ripple#send_motion_or_selection("p")<cr>
 xnoremap <silent> <Plug>(ripple_send_selection) :<c-u>call ripple#send_motion_or_selection(visualmode())<cr>
-nmap <silent> <Plug>(ripple_send_line) yr_
+nmap <silent> <Plug>(ripple_send_line) <Plug>(ripple_send_motion)_
 
 if get(g:, 'ripple_enable_mappings', s:default_enable_mappings)
     nmap y<cr> <Plug>(ripple_open_repl)


### PR DESCRIPTION
Noticed this while looking at 1754cf9. If a user disables default mappings, and maps `<Plug>(ripple_send_motion)` to something other than `yr`, `<Plug>(ripple_send_line)` won't resolve to what we want. Using the named mapping in the {rhs} makes sure it always works.