### PR TITLE
add var for passing window size expression

### DIFF
--- a/autoload/ripple.vim
+++ b/autoload/ripple.vim
@@ -175,7 +175,12 @@ function! ripple#open_repl(isolated)
             return -1
         endif
 
-        silent execute winpos." new"
+        if has_key(g:, 'ripple_winexpr')
+          silent execute winpos.eval(g:ripple_winexpr)." new"
+        else
+          silent execute winpos." new"
+        endif
+
         if has("nvim")
             silent execute "term" s:repl_params[ft][0]
             if term_name != ""


### PR DESCRIPTION
I was looking for the ability to dynamically size the repl window, so I added this variable to allow an expression of the size to be passed.

For instance you could set `let g:ripple_winexpr = "winwidth(0)/3"` in order to make the width one third of the current window.